### PR TITLE
Release 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>komposten.vivaldi</groupId>
 	<artifactId>VivaldiModder</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/komposten/vivaldi/ui/EditInstructionDialog.java
+++ b/src/main/java/komposten/vivaldi/ui/EditInstructionDialog.java
@@ -304,6 +304,9 @@ public class EditInstructionDialog extends JDialog
 		if (isFileInDirectory(file, relativeTo, true))
 		{
 			path = path.replace(relativeTo.getAbsolutePath(), "");
+			
+			if (path.startsWith("/") || path.startsWith("\\"))
+				path = path.substring(1);
 		}
 		
 		browseField.getTextfield().setText(path.replace('\\', '/'));

--- a/src/main/java/komposten/vivaldi/ui/ModPanel.java
+++ b/src/main/java/komposten/vivaldi/ui/ModPanel.java
@@ -295,7 +295,7 @@ public class ModPanel extends JPanel
 				if (child.isFile())
 				{
 					String modFile = modDir.toPath().relativize(child.toPath()).toString();
-					String target = relativeTo.toPath().relativize(child.toPath()).toString();
+					String target = relativeTo.toPath().relativize(directory.toPath()).toString();
 					
 					if (!onlyFolderContent)
 						target = DirectoryUtils.assemblePath(targetDir, relativeTo.getName(), target);

--- a/src/main/java/komposten/vivaldi/util/DirectoryUtils.java
+++ b/src/main/java/komposten/vivaldi/util/DirectoryUtils.java
@@ -19,6 +19,7 @@
 package komposten.vivaldi.util;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -126,7 +127,12 @@ public final class DirectoryUtils
 		for (int i = 0; i < elements.length; i++)
 		{
 			String element = elements[i];
-			if (i == 0 || !(elements[i-1].endsWith("/") || elements[i-1].endsWith("\\")))
+			
+			if (element.isEmpty())
+			{
+				continue;
+			}
+			else if (i == 0 || !(elements[i-1].endsWith("/") || elements[i-1].endsWith("\\")))
 			{
 				if (element.startsWith("/") || element.startsWith("\\"))
 					builder.append(element);


### PR DESCRIPTION
Fixes several issues with adding instructions:

* Browsing for a mod file added `/` before the path, making it absolute on UNIX systems.
* Selecting a folder of mods added `//` to the target paths if the chosen target path was empty.
* Selecting a folder of mods added the file names to the target paths (e.g. the file `/mods/style.css` would be given a target of `[VERSION]/mods/style.css/`).