### PR TITLE
Release 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>komposten.vivaldi</groupId>
 	<artifactId>VivaldiModder</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/komposten/vivaldi/backend/Patcher.java
+++ b/src/main/java/komposten/vivaldi/backend/Patcher.java
@@ -280,7 +280,9 @@ public class Patcher
 
 
 	/**
-	 * @return A list of all instructions that were backed up successfully.
+	 * @return A list of all instructions that were backed up successfully,
+	 *         already had backups, or did not exist (and where thus not in need
+	 *         of being backed up).
 	 */
 	private List<Instruction> backupFiles(File versionDir)
 	{
@@ -294,18 +296,15 @@ public class Patcher
 			File targetFile = new File(targetDir, sourceFile.getName());
 			File backupFile = new File(targetDir, sourceFile.getName() + ".bak");
 			
-			if (targetFile.exists())
+			if (targetFile.exists() && !backupFile.exists())
 			{
-				if (!backupFile.exists())
-				{
-					anyNeededBackup = true;
-					if (backupFile(targetFile, backupFile, versionDir))
-						instructions.add(instruction);
-				}
-				else
-				{
+				anyNeededBackup = true;
+				if (backupFile(targetFile, backupFile, versionDir))
 					instructions.add(instruction);
-				}
+			}
+			else
+			{
+				instructions.add(instruction);
 			}
 		}
 		

--- a/src/main/java/komposten/vivaldi/ui/EditInstructionDialog.java
+++ b/src/main/java/komposten/vivaldi/ui/EditInstructionDialog.java
@@ -87,7 +87,7 @@ public class EditInstructionDialog extends JDialog
 		checkOnlyFolderContent.setToolTipText(Strings.EDIT_INSTRUCTION_FOLDER_CONTENT);
 		checkIncludeSubfolders.setToolTipText(Strings.EDIT_INSTRUCTION_INCLUDE_SUBFOLDERS);
 		
-		fieldTarget.setPreferredSize(new Dimension(340, fieldTarget.getPreferredSize().height));
+		fieldTarget.setPreferredSize(new Dimension(440, fieldTarget.getPreferredSize().height));
 		
 		fieldMod.setBrowseListener(this::onModFileSelected);
 		fieldMod.getTextfield().addFocusListener(focusListener);
@@ -135,6 +135,7 @@ public class EditInstructionDialog extends JDialog
 		add(panelButtons, constraints);
 		
 		pack();
+		setResizable(false);
 		setLocationRelativeTo(owner);
 	}
 	

--- a/src/main/java/komposten/vivaldi/ui/ModPanel.java
+++ b/src/main/java/komposten/vivaldi/ui/ModPanel.java
@@ -240,9 +240,8 @@ public class ModPanel extends JPanel
 		if (showEditDialog(null) == EditInstructionDialog.RESULT_OK)
 		{
 			Instruction instruction = editDialog.getInstruction();
-			File modFile = new File(fieldModDir.getTextfield().getText(), instruction.sourceFile);
 			
-			if (modFile.isDirectory())
+			if (isModFileDirectory(instruction))
 			{
 				addDirectoryInstruction(instruction, editDialog.getOnlyFolderContent(),
 						editDialog.getIncludeSubfolders());
@@ -252,6 +251,13 @@ public class ModPanel extends JPanel
 				instructionsTable.addInstruction(instruction);
 			}
 		}
+	}
+
+
+	private boolean isModFileDirectory(Instruction instruction)
+	{
+		File modFile = new File(fieldModDir.getTextfield().getText(), instruction.sourceFile);
+		return modFile.isDirectory();
 	}
 
 
@@ -339,16 +345,32 @@ public class ModPanel extends JPanel
 		if (editDialog == null)
 			editDialog = new EditInstructionDialog(SwingUtilities.getWindowAncestor(this));
 		
-		
 		if (showEditDialog(instruction) == EditInstructionDialog.RESULT_OK)
-			instructionsTable.replaceInstruction(instruction, editDialog.getInstruction());
+		{
+			Instruction newInstruction = editDialog.getInstruction();
+			
+			if (isModFileDirectory(newInstruction))
+			{
+				removeInstructions(instruction);
+				addDirectoryInstruction(newInstruction, editDialog.getOnlyFolderContent(),
+						editDialog.getIncludeSubfolders());
+			}
+			else
+			{
+				instructionsTable.replaceInstruction(instruction, newInstruction);
+			}
+		}
 	}
 
 
 	private void removeSelectedInstructions()
 	{
-		Instruction[] instructions = instructionsTable.getSelectedInstructions();
-
+		removeInstructions(instructionsTable.getSelectedInstructions());
+	}
+	
+	
+	private void removeInstructions(Instruction... instructions)
+	{
 		if (instructions.length > 0)
 			instructionsTable.removeInstructions(instructions);
 	}


### PR DESCRIPTION
Fixes:
- #20: Selecting a folder when editing an instruction didn't add the folder contents as separate instructions.
- #22: Mod files are only copied if there is something to overwrite.
- The add/edit instruction dialog can no longer be resized.